### PR TITLE
Fix npm script name for building documentation

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -23,7 +23,7 @@ jobs:
         run: npm install
 
       - name: Build documentation
-        run: npm run build:doc
+        run: npm run build:docs
 
       - name: Deploy documentation
         run: |


### PR DESCRIPTION
Correct the npm script name in the build-docs.yaml file to ensure the documentation builds successfully.