### PR TITLE
Force add documentation changes in build-docs.yaml

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -29,6 +29,6 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add docs
+          git add -f docs
           git commit -m 'Update documentation'
           git push origin HEAD:testing


### PR DESCRIPTION
Ensure that documentation changes are added to the build process even if they are ignored by Git.