### PR TITLE
Update isInAws function for production check only

### DIFF
--- a/src/_common/config/environment.config.ts
+++ b/src/_common/config/environment.config.ts
@@ -10,7 +10,7 @@ export function isTesting() {
 }
 
 export function isInAws() {
-  return isProd() || isTesting();
+  return isProd();
 }
 
 export function isDev() {


### PR DESCRIPTION
Refine the `isInAws` function to return true exclusively for the production environment, enhancing the accuracy of environment checks.